### PR TITLE
Fix a bug related to long lines

### DIFF
--- a/gobls_test.go
+++ b/gobls_test.go
@@ -206,3 +206,34 @@ func TestScannerDoubleLine(t *testing.T) {
 		testSequenceBuffer(t, buf, want)
 	})
 }
+
+func TestScannerLongLineWithoutEndline(t *testing.T) {
+	t.Run("one long line", func(t *testing.T) {
+		buf := makeBuffer(1, 1<<16)
+		buf = buf[:len(buf)-2] // skip CLRF
+		line := string(buf)
+		want := []string{line}
+
+		testSequenceScanner(t, buf, want)
+		testSequenceBuffer(t, buf, want)
+	})
+	t.Run("multiple long lines", func(t *testing.T) {
+		buf := makeBuffer(3, 1<<16)
+		buf = buf[:len(buf)-2] // skip CLRF
+		line := string(buf[:(1<<16)-2])
+		want := []string{line, line, line}
+
+		testSequenceScanner(t, buf, want)
+		testSequenceBuffer(t, buf, want)
+	})
+	t.Run("long then short", func(t *testing.T) {
+		buf := append(makeBuffer(1, 1<<16), makeBuffer(1, 1<<8)...)
+		buf = buf[:len(buf)-2] // skip CLRF
+		line1 := string(buf[:(1<<16)-2])
+		line2 := string(buf[1<<16:])
+		want := []string{line1, line2}
+
+		testSequenceScanner(t, buf, want)
+		testSequenceBuffer(t, buf, want)
+	})
+}

--- a/scanner.go
+++ b/scanner.go
@@ -16,16 +16,16 @@ type scanner struct {
 // allocates a scanning buffer with the default buffer size.  This per-scanner
 // buffer will grow to accomodate extremely long lines.
 //
-//    var lines, characters int
-//    ls := gobls.NewScanner(os.Stdin)
-//    for ls.Scan() {
-//        lines++
-//        characters += len(ls.Bytes())
-//    }
-//    if ls.Err() != nil {
-//        fmt.Fprintln(os.Stderr, "cannot scan:", ls.Err())
-//    }
-//    fmt.Println("Counted",lines,"and",characters,"characters.")
+//	var lines, characters int
+//	ls := gobls.NewScanner(os.Stdin)
+//	for ls.Scan() {
+//	    lines++
+//	    characters += len(ls.Bytes())
+//	}
+//	if ls.Err() != nil {
+//	    fmt.Fprintln(os.Stderr, "cannot scan:", ls.Err())
+//	}
+//	fmt.Println("Counted",lines,"and",characters,"characters.")
 func NewScanner(r io.Reader) Scanner {
 	return &scanner{
 		br:          bufio.NewReader(r),
@@ -92,6 +92,7 @@ readMore:
 		return true
 	}
 	if s.err == io.EOF {
+		s.buf = s.longLineBuf
 		l := len(s.buf)
 		more := l > 0
 		if more && s.buf[l-1] == '\r' {


### PR DESCRIPTION
The current implementation ignores the rest of the line when there's no '\n' at the end of file and the line is long.
This PR fixes this issue.